### PR TITLE
Remap mouse buttons in the 2D interface 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 <!-- next-header -->
 ## 0.3.1
 
+- Improve flexibility of the cross-over suggestions interface. The parameters are in the "Eddition" tab
 - Update wgpu to 0.11
 - Files that do not have an `.ens` extensions won't be overiden when saving a design. This fixes a problem that caused
 ENSnano to overide cadnano files for example.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 <!-- next-header -->
 ## 0.3.1
 
+- Update wgpu to 0.11
 - Files that do not have an `.ens` extensions won't be overiden when saving a design. This fixes a problem that caused
 ENSnano to overide cadnano files for example.
 - Selected/candidate nucleotide are now highlighted in the 2D view.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
+
 <!-- next-header -->
+## 0.3.1
+
+- Files that do not have an `.ens` extensions won't be overiden when saving a design. This fixes a problem that caused
+ENSnano to overide cadnano files for example.
+- Selected/candidate nucleotide are now highlighted in the 2D view.
+
+
 ## 0.3.0
 - It is now possible to translate several helices at once.
 - It is now possible to change the color of several strands at once. Moreover, the red hilighting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ resolver = "2"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced = { git = "https://github.com/hecrj/iced", rev = "099981c", features=["image"] }
-iced_wgpu = { git = "https://github.com/hecrj/iced", rev = "099981c", features = ["spirv"] }
-iced_graphics = { git = "https://github.com/hecrj/iced", rev = "099981c" }
-iced_winit = { git = "https://github.com/hecrj/iced", rev = "099981c" }
-iced_native = { git = "https://github.com/hecrj/iced", rev = "099981c" }
+iced = { git = "https://github.com/hecrj/iced", rev = "61c747b53589d98f477fea95f85d2ea5349666d3", features=["image"] }
+iced_wgpu = { git = "https://github.com/hecrj/iced", rev = "61c747b53589d98f477fea95f85d2ea5349666d3", features = ["spirv"] }
+iced_graphics = { git = "https://github.com/hecrj/iced", rev = "61c747b53589d98f477fea95f85d2ea5349666d3" }
+iced_winit = { git = "https://github.com/hecrj/iced", rev = "61c747b53589d98f477fea95f85d2ea5349666d3" }
+iced_native = { git = "https://github.com/hecrj/iced", rev = "61c747b53589d98f477fea95f85d2ea5349666d3" }
 ultraviolet = { git = "https://github.com/termhn/ultraviolet", rev = "b2fb29e" , features = ["bytemuck", "f64", "serde"] }
 bytemuck = "1.2.0"
 failure = "0.1.8"
@@ -40,7 +40,7 @@ ordered-float = "2.0"
 rfd = "0.4"
 material-icons = "0.1.0"
 ensnano_organizer = { path = "ensnano-organizer" }
-iced_aw = { git = "https://github.com/thenlevy/iced_aw", rev = "b566bdb" , features = ["tab_bar"]}
+iced_aw = { git = "https://github.com/thenlevy/iced_aw", rev = "4ee0a6ac70633" , features = ["tab_bar"]}
 num_enum = "0.5.1"
 cadnano-format = "0.1.0"
 open = "1"

--- a/ensnano-design/src/lib.rs
+++ b/ensnano-design/src/lib.rs
@@ -423,6 +423,15 @@ impl Design {
     pub fn prepare_for_save(&mut self, saving_information: SavingInformation) {
         self.saved_camera = saving_information.camera;
     }
+
+    pub fn get_nucl_position(&self, nucl: Nucl) -> Option<Vec3> {
+        let helix = self.helices.get(&nucl.helix)?;
+        Some(helix.space_pos(
+            &self.parameters.unwrap_or_default(),
+            nucl.position,
+            nucl.forward,
+        ))
+    }
 }
 
 pub struct SavingInformation {

--- a/ensnano-interactor/Cargo.toml
+++ b/ensnano-interactor/Cargo.toml
@@ -29,6 +29,6 @@ num_enum = "0.5.1"
 open = "1"
 ensnano_design = { path = "../ensnano-design" }
 ensnano_organizer = { path = "../ensnano-organizer" }
-iced_wgpu = { git = "https://github.com/hecrj/iced", rev = "099981c" }
-iced_winit = { git = "https://github.com/hecrj/iced", rev = "099981c" }
+iced_wgpu = { git = "https://github.com/hecrj/iced", rev = "61c747b53589d98f477fea95f85d2ea5349666d3" }
+iced_winit = { git = "https://github.com/hecrj/iced", rev = "61c747b53589d98f477fea95f85d2ea5349666d3" }
 

--- a/ensnano-interactor/src/lib.rs
+++ b/ensnano-interactor/src/lib.rs
@@ -456,6 +456,7 @@ pub struct StrandBuildingStatus {
 pub struct SuggestionParameters {
     pub include_scaffold: bool,
     pub include_intra_strand: bool,
+    pub ignore_groups: bool,
 }
 
 impl Default for SuggestionParameters {
@@ -463,6 +464,7 @@ impl Default for SuggestionParameters {
         Self {
             include_intra_strand: true,
             include_scaffold: true,
+            ignore_groups: true,
         }
     }
 }

--- a/ensnano-interactor/src/lib.rs
+++ b/ensnano-interactor/src/lib.rs
@@ -456,6 +456,7 @@ pub struct StrandBuildingStatus {
 pub struct SuggestionParameters {
     pub include_scaffold: bool,
     pub include_intra_strand: bool,
+    pub include_xover_ends: bool,
     pub ignore_groups: bool,
 }
 
@@ -464,6 +465,7 @@ impl Default for SuggestionParameters {
         Self {
             include_intra_strand: true,
             include_scaffold: true,
+            include_xover_ends: false,
             ignore_groups: false,
         }
     }
@@ -485,6 +487,12 @@ impl SuggestionParameters {
     pub fn with_ignore_groups(&self, ignore_groups: bool) -> Self {
         let mut ret = self.clone();
         ret.ignore_groups = ignore_groups;
+        ret
+    }
+
+    pub fn with_xover_ends(&self, include_xover_ends: bool) -> Self {
+        let mut ret = self.clone();
+        ret.include_xover_ends = include_xover_ends;
         ret
     }
 }

--- a/ensnano-interactor/src/lib.rs
+++ b/ensnano-interactor/src/lib.rs
@@ -464,7 +464,7 @@ impl Default for SuggestionParameters {
         Self {
             include_intra_strand: true,
             include_scaffold: true,
-            ignore_groups: true,
+            ignore_groups: false,
         }
     }
 }
@@ -479,6 +479,12 @@ impl SuggestionParameters {
     pub fn with_intra_strand(&self, intra_strand: bool) -> Self {
         let mut ret = self.clone();
         ret.include_intra_strand = intra_strand;
+        ret
+    }
+
+    pub fn with_ignore_groups(&self, ignore_groups: bool) -> Self {
+        let mut ret = self.clone();
+        ret.ignore_groups = ignore_groups;
         ret
     }
 }

--- a/ensnano-interactor/src/lib.rs
+++ b/ensnano-interactor/src/lib.rs
@@ -450,3 +450,33 @@ pub struct StrandBuildingStatus {
     pub prime5: Nucl,
     pub dragged_nucl: Nucl,
 }
+
+/// Parameters of strand suggestions
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SuggestionParameters {
+    pub include_scaffold: bool,
+    pub include_intra_strand: bool,
+}
+
+impl Default for SuggestionParameters {
+    fn default() -> Self {
+        Self {
+            include_intra_strand: true,
+            include_scaffold: true,
+        }
+    }
+}
+
+impl SuggestionParameters {
+    pub fn with_include_scaffod(&self, include_scaffold: bool) -> Self {
+        let mut ret = self.clone();
+        ret.include_scaffold = include_scaffold;
+        ret
+    }
+
+    pub fn with_intra_strand(&self, intra_strand: bool) -> Self {
+        let mut ret = self.clone();
+        ret.include_intra_strand = intra_strand;
+        ret
+    }
+}

--- a/ensnano-organizer/Cargo.toml
+++ b/ensnano-organizer/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-iced = { git = "https://github.com/hecrj/iced", rev = "099981c", features=["image"] }
-iced_wgpu = { git = "https://github.com/hecrj/iced", rev = "099981c" }
-iced_graphics = { git = "https://github.com/hecrj/iced", rev = "099981c" }
-iced_winit = { git = "https://github.com/hecrj/iced", rev = "099981c" }
-iced_native = { git = "https://github.com/hecrj/iced", rev = "099981c" }
+iced = { git = "https://github.com/hecrj/iced", rev = "61c747b53589d98f477fea95f85d2ea5349666d3", features=["image"] }
+iced_wgpu = { git = "https://github.com/hecrj/iced", rev = "61c747b53589d98f477fea95f85d2ea5349666d3" }
+iced_graphics = { git = "https://github.com/hecrj/iced", rev = "61c747b53589d98f477fea95f85d2ea5349666d3" }
+iced_winit = { git = "https://github.com/hecrj/iced", rev = "61c747b53589d98f477fea95f85d2ea5349666d3" }
+iced_native = { git = "https://github.com/hecrj/iced", rev = "61c747b53589d98f477fea95f85d2ea5349666d3" }
 iced_aw = { git = "https://github.com/iced-rs/iced_aw", rev = "84ccfa8", features=["icons", "icon_text"] }
 serde = "1.0.116"
 serde_derive = "1.0.116"

--- a/ensnano-organizer/src/drag_drop_target.rs
+++ b/ensnano-organizer/src/drag_drop_target.rs
@@ -1,6 +1,6 @@
 use iced::{Container, Element};
 use iced_native::{
-    event, layout, overlay, Align, Clipboard, Event, Hasher, Layout, Length, Point, Rectangle,
+    event, layout, overlay, Alignment, Clipboard, Event, Hasher, Layout, Length, Point, Rectangle,
     Widget,
 };
 use std::hash::Hash;
@@ -17,8 +17,8 @@ pub(super) struct DragDropTarget<'a, Message, K> {
     height: Length,
     max_width: u32,
     max_height: u32,
-    horizontal_alignment: Align,
-    vertical_alignment: Align,
+    horizontal_alignment: Alignment,
+    vertical_alignment: Alignment,
     content: Container<'a, Message>,
     identifier: Identifier<K>,
 }
@@ -35,8 +35,8 @@ impl<'a, Message, K> DragDropTarget<'a, Message, K> {
             height: Length::Shrink,
             max_width: u32::MAX,
             max_height: u32::MAX,
-            horizontal_alignment: Align::Start,
-            vertical_alignment: Align::Start,
+            horizontal_alignment: Alignment::Start,
+            vertical_alignment: Alignment::Start,
             content: Container::new(content).width(Length::Fill),
             identifier,
         }

--- a/ensnano-organizer/src/lib.rs
+++ b/ensnano-organizer/src/lib.rs
@@ -1550,7 +1550,7 @@ impl<E: OrganizerElement> GroupContent<E> {
 }
 
 fn icon(unicode: char) -> Text {
-    use iced::HorizontalAlignment;
+    use iced::alignment::Horizontal as HorizontalAlignment;
     Text::new(&unicode.to_string())
         .font(ICONS)
         .size(ICON_SIZE)

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -37,7 +37,7 @@ use crate::apply_update;
 use crate::controller::SimulationRequest;
 use address_pointer::AddressPointer;
 use ensnano_design::Design;
-use ensnano_interactor::{DesignOperation, RigidBodyConstants};
+use ensnano_interactor::{DesignOperation, RigidBodyConstants, SuggestionParameters};
 use ensnano_organizer::GroupId;
 
 pub use design_interactor::controller::ErrOperation;
@@ -128,6 +128,12 @@ impl AppState {
         Self(AddressPointer::new(new_state))
     }
 
+    pub fn with_suggestion_parameters(&self, suggestion_parameters: SuggestionParameters) -> Self {
+        let mut new_state = (*self.0).clone();
+        new_state.suggestion_parameters = suggestion_parameters;
+        Self(AddressPointer::new(new_state))
+    }
+
     pub fn with_action_mode(&self, action_mode: ActionMode) -> Self {
         let mut new_state = (*self.0).clone();
         new_state.action_mode = action_mode;
@@ -201,7 +207,7 @@ impl AppState {
 
     fn updated(self) -> Self {
         let mut interactor = self.0.design.clone_inner();
-        interactor = interactor.with_updated_design_reader();
+        interactor = interactor.with_updated_design_reader(&self.0.suggestion_parameters);
         self.with_interactor(interactor)
     }
 
@@ -313,6 +319,7 @@ impl AppState {
         *self = self.with_candidates(vec![]);
         *self = self.with_action_mode(source.0.action_mode.clone());
         *self = self.with_selection_mode(source.0.selection_mode.clone());
+        *self = self.with_suggestion_parameters(source.0.suggestion_parameters.clone());
     }
 
     pub(super) fn is_pasting(&self) -> PastingStatus {
@@ -448,6 +455,7 @@ struct AppState_ {
     widget_basis: WidgetBasis,
     strand_on_new_helix: Option<NewHelixStrand>,
     center_of_selection: Option<CenterOfSelection>,
+    suggestion_parameters: SuggestionParameters,
 }
 
 #[derive(Clone, Default)]

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -65,6 +65,13 @@ impl std::fmt::Debug for AppState {
     }
 }
 
+impl std::fmt::Pointer for AppState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ptr = self.0.get_ptr();
+        std::fmt::Pointer::fmt(&ptr, f)
+    }
+}
+
 impl Default for AppState {
     fn default() -> Self {
         let ret = AppState(Default::default());
@@ -206,9 +213,15 @@ impl AppState {
     }
 
     fn updated(self) -> Self {
+        let old_self = self.clone();
         let mut interactor = self.0.design.clone_inner();
         interactor = interactor.with_updated_design_reader(&self.0.suggestion_parameters);
-        self.with_interactor(interactor)
+        let new = self.with_interactor(interactor);
+        if old_self.design_was_modified(&new) {
+            new
+        } else {
+            old_self
+        }
     }
 
     fn with_interactor(self, interactor: DesignInteractor) -> Self {

--- a/src/app_state/address_pointer.rs
+++ b/src/app_state/address_pointer.rs
@@ -66,6 +66,10 @@ impl<T: Default> AddressPointer<T> {
     pub fn show_address(&self) {
         println!("{:p}", Arc::as_ptr(&self.0))
     }
+
+    pub fn get_ptr(&self) -> *const T {
+        Arc::as_ptr(&self.0)
+    }
 }
 
 use std::ops::Deref;

--- a/src/app_state/design_interactor.rs
+++ b/src/app_state/design_interactor.rs
@@ -20,7 +20,7 @@ use super::AddressPointer;
 use ensnano_design::{group_attributes::GroupAttribute, Design, Parameters};
 use ensnano_interactor::{
     operation::Operation, DesignOperation, RigidBodyConstants, Selection, SimulationState,
-    StrandBuilder,
+    StrandBuilder, SuggestionParameters,
 };
 
 mod presenter;
@@ -200,12 +200,16 @@ impl DesignInteractor {
         ret
     }
 
-    pub(super) fn with_updated_design_reader(mut self) -> Self {
+    pub(super) fn with_updated_design_reader(
+        mut self,
+        suggestion_parameters: &SuggestionParameters,
+    ) -> Self {
         if cfg!(test) {
             print!("Old design: ");
             self.design.show_address();
         }
-        let (new_presenter, new_design) = update_presenter(&self.presenter, self.design.clone());
+        let (new_presenter, new_design) =
+            update_presenter(&self.presenter, self.design.clone(), suggestion_parameters);
         self.presenter = new_presenter;
         if cfg!(test) {
             print!("New design: ");
@@ -216,7 +220,7 @@ impl DesignInteractor {
             if !self.controller.get_simulation_state().is_runing() {
                 self.simulation_update = None;
             }
-            self.after_applying_simulation_update(update)
+            self.after_applying_simulation_update(update, suggestion_parameters)
         } else {
             self
         }
@@ -230,9 +234,17 @@ impl DesignInteractor {
         self
     }
 
-    fn after_applying_simulation_update(mut self, update: Arc<dyn SimulationUpdate>) -> Self {
-        let (new_presenter, new_design) =
-            apply_simulation_update(&self.presenter, self.design.clone(), update);
+    fn after_applying_simulation_update(
+        mut self,
+        update: Arc<dyn SimulationUpdate>,
+        suggestion_parameters: &SuggestionParameters,
+    ) -> Self {
+        let (new_presenter, new_design) = apply_simulation_update(
+            &self.presenter,
+            self.design.clone(),
+            update,
+            suggestion_parameters,
+        );
         self.presenter = new_presenter;
         self.design = new_design;
         self
@@ -425,7 +437,8 @@ mod tests {
     fn read_one_helix() {
         let path = one_helix_path();
         let interactor = DesignInteractor::new_with_path(&path).ok().unwrap();
-        let interactor = interactor.with_updated_design_reader();
+        let suggestion_parameters = Default::default();
+        let interactor = interactor.with_updated_design_reader(&suggestion_parameters);
         let reader = interactor.get_design_reader();
         assert_eq!(reader.get_all_visible_nucl_ids().len(), 24)
     }
@@ -817,7 +830,6 @@ mod tests {
 
     #[test]
     fn positioning_xovers_paste() {
-        use crate::flatscene::DesignReader;
         let mut app_state = pastable_design();
         let (n1, n2) = app_state.get_design_reader().get_xover_with_id(0).unwrap();
         app_state
@@ -851,7 +863,6 @@ mod tests {
 
     #[test]
     fn pasting_when_positioning_xovers() {
-        use crate::flatscene::DesignReader;
         let mut app_state = pastable_design();
         let (n1, n2) = app_state.get_design_reader().get_xover_with_id(0).unwrap();
         app_state
@@ -865,7 +876,6 @@ mod tests {
 
     #[test]
     fn duplicating_xovers() {
-        use crate::flatscene::DesignReader;
         let mut app_state = pastable_design();
         let (n1, n2) = app_state.get_design_reader().get_xover_with_id(0).unwrap();
         app_state
@@ -899,7 +909,6 @@ mod tests {
 
     #[test]
     fn duplicating_xovers_pasting_status() {
-        use crate::flatscene::DesignReader;
         let mut app_state = pastable_design();
         let (n1, n2) = app_state.get_design_reader().get_xover_with_id(0).unwrap();
         app_state

--- a/src/app_state/design_interactor/controller/clipboard.rs
+++ b/src/app_state/design_interactor/controller/clipboard.rs
@@ -315,7 +315,7 @@ impl Controller {
         let mut domains_vec = vec![domains_0];
         for n in 1..clipboard.templates.len() {
             let t = clipboard.templates.get(n);
-            println!("updated template {:?}", t);
+            log::info!("updated template {:?}", t);
             let domains = t.as_ref().and_then(|t| {
                 clipboard
                     .template_edges
@@ -760,9 +760,9 @@ impl Controller {
         let (edge, shift) = copy_edge;
         for (n1, n2) in xovers.iter() {
             let copy_1 = self.translate_nucl_by_edge(n1, &edge, shift, design, grid_manager);
-            println!("copy 1 {:?}", copy_1);
+            log::debug!("copy 1 {:?}", copy_1);
             let copy_2 = self.translate_nucl_by_edge(n2, &edge, shift, design, grid_manager);
-            println!("copy 2 {:?}", copy_2);
+            log::debug!("copy 2 {:?}", copy_2);
             if let Some((copy_1, copy_2)) = copy_1.zip(copy_2) {
                 if !design.is_true_xover_end(&copy_1) && !design.is_true_xover_end(&copy_2) {
                     // If general_cross_over returns an error we simply ignore this cross_over

--- a/src/app_state/design_interactor/file_parsing.rs
+++ b/src/app_state/design_interactor/file_parsing.rs
@@ -41,7 +41,9 @@ impl DesignInteractor {
             s.read_junctions(&mut xover_ids, false);
         }
         //let file_name = real_name(json_path);
-        let (presenter, design_ptr) = Presenter::from_new_design(design, &xover_ids);
+        let suggestion_parameters = SuggestionParameters::default();
+        let (presenter, design_ptr) =
+            Presenter::from_new_design(design, &xover_ids, suggestion_parameters);
         let ret = Self {
             design: design_ptr,
             presenter: AddressPointer::new(presenter),

--- a/src/app_state/design_interactor/file_parsing.rs
+++ b/src/app_state/design_interactor/file_parsing.rs
@@ -62,7 +62,7 @@ fn read_file<P: AsRef<Path> + std::fmt::Debug>(path: P) -> Result<Design, ParseD
     let design: Result<Design, _> = serde_json::from_str(&json_str);
     // First try to read icednano format
     if let Ok(design) = design {
-        println!("ok icednano");
+        log::info!("ok icednano");
         Ok(design)
     } else {
         // If the file is not in icednano format, try the other supported format
@@ -74,11 +74,11 @@ fn read_file<P: AsRef<Path> + std::fmt::Debug>(path: P) -> Result<Design, ParseD
         if let Ok(scadnano) = scadnano_design {
             Design::from_scadnano(&scadnano).map_err(|e| ParseDesignError::ScadnanoError(e))
         } else if let Ok(design) = cdn_design {
-            println!("{:?}", scadnano_design.err());
-            println!("ok codenano");
+            log::error!("{:?}", scadnano_design.err());
+            log::info!("ok codenano");
             Ok(Design::from_codenano(&design))
         } else if let Ok(cadnano) = Cadnano::from_file(path) {
-            println!("ok cadnano");
+            log::info!("ok cadnano");
             Ok(Design::from_cadnano(cadnano))
         } else {
             // The file is not in any supported format

--- a/src/app_state/design_interactor/presenter.rs
+++ b/src/app_state/design_interactor/presenter.rs
@@ -21,7 +21,9 @@ pub use self::design_content::Staple;
 
 use super::*;
 use ensnano_design::{Extremity, Nucl};
-use ensnano_interactor::{NeighbourDescriptor, NeighbourDescriptorGiver, ScaffoldInfo, Selection};
+use ensnano_interactor::{
+    NeighbourDescriptor, NeighbourDescriptorGiver, ScaffoldInfo, Selection, SuggestionParameters,
+};
 use ultraviolet::Mat4;
 
 use crate::utils::id_generator::IdGenerator;
@@ -48,6 +50,7 @@ use std::collections::{BTreeMap, HashSet};
 /// structures, the strucutres are updated before returning the design reader.
 pub(super) struct Presenter {
     pub current_design: AddressPointer<Design>,
+    current_suggestion_paramters: SuggestionParameters,
     model_matrix: AddressPointer<Mat4>,
     content: AddressPointer<DesignContent>,
     pub junctions_ids: AddressPointer<JunctionsIds>,
@@ -60,6 +63,7 @@ impl Default for Presenter {
     fn default() -> Self {
         Self {
             current_design: Default::default(),
+            current_suggestion_paramters: Default::default(),
             model_matrix: AddressPointer::new(Mat4::identity()),
             content: Default::default(),
             junctions_ids: Default::default(),
@@ -91,9 +95,15 @@ impl Presenter {
         }
     }
 
-    pub fn update(mut self, design: AddressPointer<Design>) -> Self {
-        if self.current_design != design {
-            self.read_design(design);
+    pub fn update(
+        mut self,
+        design: AddressPointer<Design>,
+        suggestion_parameters: &SuggestionParameters,
+    ) -> Self {
+        if self.current_design != design
+            || &self.current_suggestion_paramters != suggestion_parameters
+        {
+            self.read_design(design, suggestion_parameters);
             self.read_scaffold_seq();
             self.update_visibility();
         }
@@ -105,14 +115,20 @@ impl Presenter {
     pub fn from_new_design(
         design: Design,
         old_junctions_ids: &JunctionsIds,
+        suggestion_parameters: SuggestionParameters,
     ) -> (Self, AddressPointer<Design>) {
         let model_matrix = Mat4::identity();
         let mut old_grid_ptr = None;
-        let (content, design, junctions_ids) =
-            DesignContent::make_hash_maps(design, old_junctions_ids, &mut old_grid_ptr);
+        let (content, design, junctions_ids) = DesignContent::make_hash_maps(
+            design,
+            old_junctions_ids,
+            &mut old_grid_ptr,
+            &suggestion_parameters,
+        );
         let design = AddressPointer::new(design);
         let ret = Self {
             current_design: design.clone(),
+            current_suggestion_paramters: suggestion_parameters,
             content: AddressPointer::new(content),
             model_matrix: AddressPointer::new(model_matrix),
             junctions_ids: AddressPointer::new(junctions_ids),
@@ -132,15 +148,21 @@ impl Presenter {
         self.content = AddressPointer::new(new_content);
     }
 
-    fn read_design(&mut self, design: AddressPointer<Design>) {
+    fn read_design(
+        &mut self,
+        design: AddressPointer<Design>,
+        suggestion_parameters: &SuggestionParameters,
+    ) {
         let (content, new_design, new_junctions_ids) = DesignContent::make_hash_maps(
             design.clone_inner(),
             self.junctions_ids.as_ref(),
             &mut self.old_grid_ptr,
+            suggestion_parameters,
         );
         self.current_design = AddressPointer::new(new_design);
         self.content = AddressPointer::new(content);
         self.junctions_ids = AddressPointer::new(new_junctions_ids);
+        self.current_suggestion_paramters = suggestion_parameters.clone();
     }
 
     pub(super) fn has_different_model_matrix_than(&self, other: &Self) -> bool {
@@ -322,12 +344,17 @@ impl Presenter {
 pub(super) fn update_presenter(
     presenter: &AddressPointer<Presenter>,
     design: AddressPointer<Design>,
+    suggestion_parameters: &SuggestionParameters,
 ) -> (AddressPointer<Presenter>, AddressPointer<Design>) {
-    if presenter.current_design != design {
+    if presenter.current_design != design
+        || &presenter.current_suggestion_paramters != suggestion_parameters
+    {
         if cfg!(test) {
             println!("updating presenter");
         }
-        let new_presenter = presenter.clone_inner().update(design);
+        let new_presenter = presenter
+            .clone_inner()
+            .update(design, suggestion_parameters);
         let design = new_presenter.current_design.clone();
         (AddressPointer::new(new_presenter), design)
     } else {
@@ -339,11 +366,15 @@ pub(super) fn apply_simulation_update(
     presenter: &AddressPointer<Presenter>,
     design: AddressPointer<Design>,
     update: impl AsRef<dyn SimulationUpdate>,
+    suggestion_parameters: &SuggestionParameters,
 ) -> (AddressPointer<Presenter>, AddressPointer<Design>) {
     let mut new_design = design.clone_inner();
     update.as_ref().update_design(&mut new_design);
-    let (new_presenter, returned_design) =
-        update_presenter(presenter, AddressPointer::new(new_design));
+    let (new_presenter, returned_design) = update_presenter(
+        presenter,
+        AddressPointer::new(new_design),
+        suggestion_parameters,
+    );
     let mut new_content = new_presenter.content.clone_inner();
     let mut returned_presenter = new_presenter.clone_inner();
     new_content.read_simualtion_update(update.as_ref());

--- a/src/app_state/design_interactor/presenter/design_content.rs
+++ b/src/app_state/design_interactor/presenter/design_content.rs
@@ -30,6 +30,9 @@ use ultraviolet::Vec3;
 
 use grid_data::GridManager;
 
+mod xover_suggestions;
+use xover_suggestions::XoverSuggestions;
+
 #[derive(Default, Clone)]
 pub(super) struct DesignContent {
     /// Maps identifer of elements to their object type
@@ -51,10 +54,6 @@ pub(super) struct DesignContent {
     /// Maps the identifier of an element to its color
     pub color: HashMap<u32, u32, RandomState>,
     pub basis_map: Arc<HashMap<Nucl, char, RandomState>>,
-    /// The position in space of the nucleotides in the Red group
-    pub red_cubes: HashMap<(isize, isize, isize), Vec<Nucl>, RandomState>,
-    /// The list of nucleotides in the blue group
-    pub blue_nucl: Vec<Nucl>,
     pub prime3_set: Vec<Prime3End>,
     pub elements: Vec<DnaElement>,
     pub suggestions: Vec<(Nucl, Nucl)>,
@@ -284,94 +283,6 @@ impl DesignContent {
             .map(|t| *t.0)
             .collect()
     }
-
-    /// Return the list of all suggested crossovers
-    fn get_suggestions(
-        &self,
-        design: &Design,
-        suggestion_parameters: &SuggestionParameters,
-    ) -> Vec<(Nucl, Nucl)> {
-        let mut ret = vec![];
-        for blue_nucl in self.blue_nucl.iter() {
-            let neighbour = self
-                .get_possible_cross_over(design, blue_nucl, suggestion_parameters)
-                .unwrap_or_default();
-            for (red_nucl, dist) in neighbour {
-                ret.push((*blue_nucl, red_nucl, dist))
-            }
-        }
-        ret.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
-        self.trimm_suggestion(&ret)
-    }
-
-    /// Trimm a list of crossovers so that each nucleotide appears at most once in the suggestion
-    /// list.
-    fn trimm_suggestion(&self, suggestion: &[(Nucl, Nucl, f32)]) -> Vec<(Nucl, Nucl)> {
-        let mut used = HashSet::new();
-        let mut ret = vec![];
-        for (a, b, _) in suggestion {
-            if !used.contains(a) && !used.contains(b) {
-                ret.push((*a, *b));
-                used.insert(a);
-                used.insert(b);
-            }
-        }
-        ret
-    }
-
-    /// Return all the crossovers of length less than `len_crit` involving `nucl`, and their length.
-    fn get_possible_cross_over(
-        &self,
-        design: &Design,
-        nucl: &Nucl,
-        suggestion_parameters: &SuggestionParameters,
-    ) -> Option<Vec<(Nucl, f32)>> {
-        let mut ret = Vec::new();
-        let positions = self
-            .identifier_nucl
-            .get(nucl)
-            .and_then(|id| self.space_position.get(id))?;
-        let cube0 = space_to_cube(positions[0], positions[1], positions[2]);
-
-        let len_crit = 1.2;
-        for i in vec![-1, 0, 1].iter() {
-            for j in vec![-1, 0, 1].iter() {
-                for k in vec![-1, 0, 1].iter() {
-                    let cube = (cube0.0 + i, cube0.1 + j, cube0.2 + k);
-                    if let Some(v) = self.red_cubes.get(&cube) {
-                        for red_nucl in v {
-                            if red_nucl.helix != nucl.helix {
-                                if let Some(red_position) = self
-                                    .identifier_nucl
-                                    .get(&red_nucl)
-                                    .and_then(|id| self.space_position.get(id))
-                                {
-                                    let dist = (0..3)
-                                        .map(|i| (positions[i], red_position[i]))
-                                        .map(|(x, y)| (x - y) * (x - y))
-                                        .sum::<f32>()
-                                        .sqrt();
-                                    if dist < len_crit
-                                        && (suggestion_parameters.include_scaffold
-                                            || design.get_strand_nucl(nucl) != design.scaffold_id)
-                                        && (suggestion_parameters.include_scaffold
-                                            || design.get_strand_nucl(red_nucl)
-                                                != design.scaffold_id)
-                                        && (suggestion_parameters.include_intra_strand
-                                            || design.get_strand_nucl(nucl)
-                                                != design.get_strand_nucl(red_nucl))
-                                    {
-                                        ret.push((*red_nucl, dist));
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        Some(ret)
-    }
 }
 
 #[derive(Debug)]
@@ -417,11 +328,10 @@ impl DesignContent {
         let mut nucl_id;
         let mut old_nucl: Option<Nucl> = None;
         let mut old_nucl_id = None;
-        let mut red_cubes = HashMap::default();
         let mut elements = Vec::new();
         let mut prime3_set = Vec::new();
-        let mut blue_nucl = Vec::new();
         let mut new_junctions: JunctionsIds = Default::default();
+        let mut suggestion_maker = XoverSuggestions::default();
         xover_ids.agree_on_next_id(&mut new_junctions);
         let mut grid_manager = GridManager::new_from_design(&design);
         if *old_grid_ptr != Some(Arc::as_ptr(&design.grids) as usize) {
@@ -495,16 +405,7 @@ impl DesignContent {
                             basis_map.remove(&nucl);
                         }
                         strand_position += 1;
-                        match groups.get(&nucl.helix) {
-                            Some(true) => {
-                                blue_nucl.push(nucl);
-                            }
-                            Some(false) => {
-                                let cube = space_to_cube(position.x, position.y, position.z);
-                                red_cubes.entry(cube).or_insert(vec![]).push(nucl.clone());
-                            }
-                            None => (),
-                        }
+                        suggestion_maker.add_nucl(nucl, position, groups.as_ref());
                         let position = [position[0] as f32, position[1] as f32, position[2] as f32];
                         space_position.insert(nucl_id, position);
                         if let Some(old_nucl) = old_nucl.take() {
@@ -602,14 +503,12 @@ impl DesignContent {
             color: color_map,
             helix_map,
             basis_map: Arc::new(basis_map),
-            red_cubes,
             prime3_set,
-            blue_nucl,
             elements,
             grid_manager,
             suggestions: vec![],
         };
-        let suggestions = ret.get_suggestions(&design, suggestion_parameters);
+        let suggestions = suggestion_maker.get_suggestions(&design, suggestion_parameters);
         ret.suggestions = suggestions;
 
         drop(groups);
@@ -658,15 +557,6 @@ impl DesignContent {
     pub fn read_simualtion_update(&mut self, update: &dyn SimulationUpdate) {
         update.update_positions(&self.identifier_nucl, &mut self.space_position)
     }
-}
-
-fn space_to_cube(x: f32, y: f32, z: f32) -> (isize, isize, isize) {
-    let cube_len = 1.2;
-    (
-        x.div_euclid(cube_len) as isize,
-        y.div_euclid(cube_len) as isize,
-        z.div_euclid(cube_len) as isize,
-    )
 }
 
 #[cfg(test)]

--- a/src/app_state/design_interactor/presenter/design_content/xover_suggestions.rs
+++ b/src/app_state/design_interactor/presenter/design_content/xover_suggestions.rs
@@ -23,6 +23,8 @@ use ultraviolet::Vec3;
 
 type CubeMap = HashMap<(isize, isize, isize), Vec<Nucl>, RandomState>;
 
+const LEN_CRIT: f32 = 1.2;
+
 #[derive(Default, Debug, Clone)]
 pub(super) struct XoverSuggestions {
     helices_groups: BTreeMap<usize, Vec<Nucl>>,
@@ -67,16 +69,30 @@ impl XoverSuggestions {
         suggestion_parameters: &SuggestionParameters,
     ) -> Vec<(Nucl, Nucl)> {
         let mut ret = vec![];
+        if suggestion_parameters.ignore_groups {
+            self.get_suggestions_all_helices(&mut ret, design, suggestion_parameters);
+        } else {
+            self.get_suggestions_groups(&mut ret, design, suggestion_parameters);
+        }
+        ret.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
+        self.trimm_suggestion(&ret)
+    }
+
+    /// Return the list of all suggested crossovers
+    fn get_suggestions_groups(
+        &self,
+        ret: &mut Vec<(Nucl, Nucl, f32)>,
+        design: &Design,
+        suggestion_parameters: &SuggestionParameters,
+    ) {
         for blue_nucl in self.blue_nucl.iter() {
             let neighbour = self
-                .get_possible_cross_over(design, blue_nucl, suggestion_parameters)
+                .get_possible_cross_over_groups(design, blue_nucl, suggestion_parameters)
                 .unwrap_or_default();
             for (red_nucl, dist) in neighbour {
                 ret.push((*blue_nucl, red_nucl, dist))
             }
         }
-        ret.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
-        self.trimm_suggestion(&ret)
     }
 
     /// Trimm a list of crossovers so that each nucleotide appears at most once in the suggestion
@@ -94,8 +110,75 @@ impl XoverSuggestions {
         ret
     }
 
+    fn get_suggestions_all_helices(
+        &self,
+        ret: &mut Vec<(Nucl, Nucl, f32)>,
+        design: &Design,
+        suggestion_parameters: &SuggestionParameters,
+    ) {
+        for nucls in self.helices_groups.values() {
+            for n in nucls.iter() {
+                let neighbour = self
+                    .get_possible_cross_over_all_helices(design, n, suggestion_parameters)
+                    .unwrap_or_default();
+                for (red_nucl, dist) in neighbour {
+                    ret.push((*n, red_nucl, dist))
+                }
+            }
+        }
+    }
+
+    fn get_possible_cross_over_all_helices(
+        &self,
+        design: &Design,
+        nucl: &Nucl,
+        suggestion_parameters: &SuggestionParameters,
+    ) -> Option<Vec<(Nucl, f32)>> {
+        let mut ret = Vec::new();
+        let positions = design.get_nucl_position(*nucl)?;
+        let cube0 = space_to_cube(positions[0], positions[1], positions[2]);
+        for i in vec![-1, 0, 1].iter() {
+            for j in vec![-1, 0, 1].iter() {
+                for k in vec![-1, 0, 1].iter() {
+                    let cube = (cube0.0 + i, cube0.1 + j, cube0.2 + k);
+
+                    for (_, cubes) in self.helices_cubes.iter().filter(|(h, _)| **h > nucl.helix) {
+                        if let Some(v) = cubes.get(&cube) {
+                            for red_nucl in v {
+                                if red_nucl.helix != nucl.helix {
+                                    if let Some(red_position) = design.get_nucl_position(*red_nucl)
+                                    {
+                                        let dist = (0..3)
+                                            .map(|i| (positions[i], red_position[i]))
+                                            .map(|(x, y)| (x - y) * (x - y))
+                                            .sum::<f32>()
+                                            .sqrt();
+                                        if dist < LEN_CRIT
+                                            && (suggestion_parameters.include_scaffold
+                                                || design.get_strand_nucl(nucl)
+                                                    != design.scaffold_id)
+                                            && (suggestion_parameters.include_scaffold
+                                                || design.get_strand_nucl(red_nucl)
+                                                    != design.scaffold_id)
+                                            && (suggestion_parameters.include_intra_strand
+                                                || design.get_strand_nucl(nucl)
+                                                    != design.get_strand_nucl(red_nucl))
+                                        {
+                                            ret.push((*red_nucl, dist));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Some(ret)
+    }
+
     /// Return all the crossovers of length less than `len_crit` involving `nucl`, and their length.
-    fn get_possible_cross_over(
+    fn get_possible_cross_over_groups(
         &self,
         design: &Design,
         nucl: &Nucl,
@@ -105,11 +188,11 @@ impl XoverSuggestions {
         let positions = design.get_nucl_position(*nucl)?;
         let cube0 = space_to_cube(positions[0], positions[1], positions[2]);
 
-        let len_crit = 1.2;
         for i in vec![-1, 0, 1].iter() {
             for j in vec![-1, 0, 1].iter() {
                 for k in vec![-1, 0, 1].iter() {
                     let cube = (cube0.0 + i, cube0.1 + j, cube0.2 + k);
+
                     if let Some(v) = self.red_cubes.get(&cube) {
                         for red_nucl in v {
                             if red_nucl.helix != nucl.helix {
@@ -119,7 +202,7 @@ impl XoverSuggestions {
                                         .map(|(x, y)| (x - y) * (x - y))
                                         .sum::<f32>()
                                         .sqrt();
-                                    if dist < len_crit
+                                    if dist < LEN_CRIT
                                         && (suggestion_parameters.include_scaffold
                                             || design.get_strand_nucl(nucl) != design.scaffold_id)
                                         && (suggestion_parameters.include_scaffold

--- a/src/app_state/design_interactor/presenter/design_content/xover_suggestions.rs
+++ b/src/app_state/design_interactor/presenter/design_content/xover_suggestions.rs
@@ -75,7 +75,7 @@ impl XoverSuggestions {
             self.get_suggestions_groups(&mut ret, design, suggestion_parameters);
         }
         ret.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
-        self.trimm_suggestion(&ret)
+        self.trimm_suggestion(&ret, design)
     }
 
     /// Return the list of all suggested crossovers
@@ -97,14 +97,22 @@ impl XoverSuggestions {
 
     /// Trimm a list of crossovers so that each nucleotide appears at most once in the suggestion
     /// list.
-    fn trimm_suggestion(&self, suggestion: &[(Nucl, Nucl, f32)]) -> Vec<(Nucl, Nucl)> {
+    fn trimm_suggestion(
+        &self,
+        suggestion: &[(Nucl, Nucl, f32)],
+        design: &Design,
+    ) -> Vec<(Nucl, Nucl)> {
         let mut used = HashSet::new();
         let mut ret = vec![];
         for (a, b, _) in suggestion {
             if !used.contains(a) && !used.contains(b) {
-                ret.push((*a, *b));
-                used.insert(a);
-                used.insert(b);
+                let a_end = design.is_strand_end(a).to_opt();
+                let b_end = design.is_strand_end(b).to_opt();
+                if !matches!(a_end.zip(b_end), Some((a, b)) if a == b) {
+                    ret.push((*a, *b));
+                    used.insert(a);
+                    used.insert(b);
+                }
             }
         }
         ret

--- a/src/app_state/design_interactor/presenter/design_content/xover_suggestions.rs
+++ b/src/app_state/design_interactor/presenter/design_content/xover_suggestions.rs
@@ -75,7 +75,7 @@ impl XoverSuggestions {
             self.get_suggestions_groups(&mut ret, design, suggestion_parameters);
         }
         ret.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
-        self.trimm_suggestion(&ret, design)
+        self.trimm_suggestion(&ret, design, suggestion_parameters)
     }
 
     /// Return the list of all suggested crossovers
@@ -101,6 +101,7 @@ impl XoverSuggestions {
         &self,
         suggestion: &[(Nucl, Nucl, f32)],
         design: &Design,
+        suggestion_parameters: &SuggestionParameters,
     ) -> Vec<(Nucl, Nucl)> {
         let mut used = HashSet::new();
         let mut ret = vec![];
@@ -108,7 +109,10 @@ impl XoverSuggestions {
             if !used.contains(a) && !used.contains(b) {
                 let a_end = design.is_strand_end(a).to_opt();
                 let b_end = design.is_strand_end(b).to_opt();
-                if !matches!(a_end.zip(b_end), Some((a, b)) if a == b) {
+                if !matches!(a_end.zip(b_end), Some((a, b)) if a == b)
+                    && (suggestion_parameters.include_xover_ends
+                        || (!design.is_true_xover_end(a) && !design.is_true_xover_end(b)))
+                {
                     ret.push((*a, *b));
                     used.insert(a);
                     used.insert(b);

--- a/src/app_state/design_interactor/presenter/design_content/xover_suggestions.rs
+++ b/src/app_state/design_interactor/presenter/design_content/xover_suggestions.rs
@@ -1,0 +1,152 @@
+/*
+ENSnano, a 3d graphical application for DNA nanostructures.
+    Copyright (C) 2021  Nicolas Levy <nicolaspierrelevy@gmail.com> and Nicolas Schabanel <nicolas.schabanel@ens-lyon.fr>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+use super::{Design, Nucl, SuggestionParameters};
+use ahash::RandomState;
+use std::collections::{BTreeMap, HashMap, HashSet};
+use ultraviolet::Vec3;
+
+type CubeMap = HashMap<(isize, isize, isize), Vec<Nucl>, RandomState>;
+
+#[derive(Default, Debug, Clone)]
+pub(super) struct XoverSuggestions {
+    helices_groups: BTreeMap<usize, Vec<Nucl>>,
+    helices_cubes: BTreeMap<usize, CubeMap>,
+    blue_nucl: Vec<Nucl>,
+    red_cubes: CubeMap,
+}
+
+impl XoverSuggestions {
+    pub(super) fn add_nucl(&mut self, nucl: Nucl, space_pos: Vec3, groups: &BTreeMap<usize, bool>) {
+        let cube = space_to_cube(space_pos.x, space_pos.y, space_pos.z);
+
+        self.helices_groups
+            .entry(nucl.helix)
+            .or_default()
+            .push(nucl.clone());
+        self.helices_cubes
+            .entry(nucl.helix)
+            .or_default()
+            .entry(cube)
+            .or_default()
+            .push(nucl);
+
+        match groups.get(&nucl.helix) {
+            Some(true) => {
+                self.blue_nucl.push(nucl);
+            }
+            Some(false) => {
+                self.red_cubes
+                    .entry(cube)
+                    .or_insert(vec![])
+                    .push(nucl.clone());
+            }
+            None => (),
+        }
+    }
+
+    /// Return the list of all suggested crossovers
+    pub(super) fn get_suggestions(
+        &self,
+        design: &Design,
+        suggestion_parameters: &SuggestionParameters,
+    ) -> Vec<(Nucl, Nucl)> {
+        let mut ret = vec![];
+        for blue_nucl in self.blue_nucl.iter() {
+            let neighbour = self
+                .get_possible_cross_over(design, blue_nucl, suggestion_parameters)
+                .unwrap_or_default();
+            for (red_nucl, dist) in neighbour {
+                ret.push((*blue_nucl, red_nucl, dist))
+            }
+        }
+        ret.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
+        self.trimm_suggestion(&ret)
+    }
+
+    /// Trimm a list of crossovers so that each nucleotide appears at most once in the suggestion
+    /// list.
+    fn trimm_suggestion(&self, suggestion: &[(Nucl, Nucl, f32)]) -> Vec<(Nucl, Nucl)> {
+        let mut used = HashSet::new();
+        let mut ret = vec![];
+        for (a, b, _) in suggestion {
+            if !used.contains(a) && !used.contains(b) {
+                ret.push((*a, *b));
+                used.insert(a);
+                used.insert(b);
+            }
+        }
+        ret
+    }
+
+    /// Return all the crossovers of length less than `len_crit` involving `nucl`, and their length.
+    fn get_possible_cross_over(
+        &self,
+        design: &Design,
+        nucl: &Nucl,
+        suggestion_parameters: &SuggestionParameters,
+    ) -> Option<Vec<(Nucl, f32)>> {
+        let mut ret = Vec::new();
+        let positions = design.get_nucl_position(*nucl)?;
+        let cube0 = space_to_cube(positions[0], positions[1], positions[2]);
+
+        let len_crit = 1.2;
+        for i in vec![-1, 0, 1].iter() {
+            for j in vec![-1, 0, 1].iter() {
+                for k in vec![-1, 0, 1].iter() {
+                    let cube = (cube0.0 + i, cube0.1 + j, cube0.2 + k);
+                    if let Some(v) = self.red_cubes.get(&cube) {
+                        for red_nucl in v {
+                            if red_nucl.helix != nucl.helix {
+                                if let Some(red_position) = design.get_nucl_position(*red_nucl) {
+                                    let dist = (0..3)
+                                        .map(|i| (positions[i], red_position[i]))
+                                        .map(|(x, y)| (x - y) * (x - y))
+                                        .sum::<f32>()
+                                        .sqrt();
+                                    if dist < len_crit
+                                        && (suggestion_parameters.include_scaffold
+                                            || design.get_strand_nucl(nucl) != design.scaffold_id)
+                                        && (suggestion_parameters.include_scaffold
+                                            || design.get_strand_nucl(red_nucl)
+                                                != design.scaffold_id)
+                                        && (suggestion_parameters.include_intra_strand
+                                            || design.get_strand_nucl(nucl)
+                                                != design.get_strand_nucl(red_nucl))
+                                    {
+                                        ret.push((*red_nucl, dist));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Some(ret)
+    }
+}
+
+fn space_to_cube(x: f32, y: f32, z: f32) -> (isize, isize, isize) {
+    let cube_len = 1.2;
+    (
+        x.div_euclid(cube_len) as isize,
+        y.div_euclid(cube_len) as isize,
+        z.div_euclid(cube_len) as isize,
+    )
+}

--- a/src/app_state/impl_app3d.rs
+++ b/src/app_state/impl_app3d.rs
@@ -96,6 +96,10 @@ impl App3D for AppState {
     fn get_current_group_id(&self) -> Option<ensnano_design::GroupId> {
         self.0.selection.selected_group
     }
+
+    fn suggestion_parameters_were_updated(&self, other: &Self) -> bool {
+        self.0.suggestion_parameters != other.0.suggestion_parameters
+    }
 }
 
 #[cfg(test)]

--- a/src/app_state/impl_gui.rs
+++ b/src/app_state/impl_gui.rs
@@ -110,6 +110,10 @@ impl GuiState for AppState {
     fn get_selected_group(&self) -> Option<GroupId> {
         self.0.selection.selected_group.clone()
     }
+
+    fn get_suggestion_parameters(&self) -> &SuggestionParameters {
+        &self.0.suggestion_parameters
+    }
 }
 
 #[cfg(test)]

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -123,3 +123,5 @@ Please ignore messages of the following form:\n
 
 pub const RGB_HANDLE_COLORS: [u32; 3] = [0xFF0000, 0xFF00, 0xFF];
 pub const CYM_HANDLE_COLORS: [u32; 3] = [0x00FFFF, 0xFF00FF, 0xFFFF00];
+
+pub const ENS_EXTENSION: &'static str = "ens";

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -113,10 +113,6 @@ pub const WELCOME_MSG: &str = "
                                WELCOME TO ENSNANO\n
 During runtime, the console may print error messages that are useful to the
 programer to investigate bugs.\n
-However, because of a current bug in wgpu, some error messages may be prompted
-that could be safely ignored.
-Please ignore messages of the following form:\n
-\"ERROR wgpu_core::validation > Unexpected varying type: Array { ... }\"\n
 ==============================================================================
 ==============================================================================
 ";

--- a/src/controller/normal_state.rs
+++ b/src/controller/normal_state.rs
@@ -31,7 +31,10 @@ impl State for NormalState {
                 Action::NewDesign => Box::new(NewDesign::init(main_state.need_save())),
                 Action::SaveAs => save_as(),
                 Action::QuickSave => {
-                    if let Some(path) = main_state.get_current_file_name() {
+                    if let Some(path) = main_state
+                        .get_current_file_name()
+                        .filter(|p| p.extension() == Some(crate::consts::ENS_EXTENSION.as_ref()))
+                    {
                         quicksave(path)
                     } else {
                         save_as()

--- a/src/flatscene.rs
+++ b/src/flatscene.rs
@@ -444,7 +444,11 @@ impl<S: AppState> FlatScene<S> {
                 .borrow_mut()
                 .perform_update(&new_state, &self.old_state);
             self.old_state = new_state;
-            view.borrow().needs_redraw()
+            let ret = view.borrow().needs_redraw();
+            if ret {
+                log::debug!("Flatscene requests redraw");
+            }
+            ret
         } else {
             false
         }

--- a/src/flatscene/controller/automata.rs
+++ b/src/flatscene/controller/automata.rs
@@ -429,7 +429,6 @@ impl<S: AppState> ControllerState<S> for NormalState {
     }
 
     fn transition_to(&self, controller: &Controller<S>) {
-        controller.data.borrow_mut().set_selected_helices(vec![]);
         controller.data.borrow_mut().set_free_end(None);
     }
 

--- a/src/flatscene/controller/automata.rs
+++ b/src/flatscene/controller/automata.rs
@@ -1074,7 +1074,13 @@ impl<S: AppState> ControllerState<S> for Rotating {
                         &controller.get_camera(position.y),
                     );
                     let consequences = if let ClickResult::Nucl(nucl) = click_result {
-                        Consequence::Cut(nucl)
+                        if let Some(attachement) =
+                            controller.data.borrow().attachable_neighbour(nucl)
+                        {
+                            Consequence::Xover(nucl, attachement)
+                        } else {
+                            Consequence::Cut(nucl)
+                        }
                     } else {
                         Consequence::Nothing
                     };

--- a/src/flatscene/data.rs
+++ b/src/flatscene/data.rs
@@ -876,8 +876,8 @@ impl Data {
                         } else {
                             new_selection.push(selection);
                         }
-                    } else if let Some(s_id) = self.design.get_strand_id(nucl.to_real()) {
-                        let selection = Selection::Strand(self.id, s_id as u32);
+                    } else {
+                        let selection = Selection::Nucleotide(self.id, nucl.to_real());
                         if let Some(pos) = new_selection.iter().position(|x| *x == selection) {
                             new_selection.remove(pos);
                         } else {

--- a/src/flatscene/data.rs
+++ b/src/flatscene/data.rs
@@ -110,28 +110,33 @@ impl Data {
         let mut candidate_xovers = HashSet::new();
         let mut selected_helices = Vec::new();
         let mut candidate_helices = Vec::new();
+        let mut candidate_nucls = Vec::new();
+        let mut selected_nucls = Vec::new();
         let id_map = self.design.id_map();
-        if !new_state.is_changing_color() {
-            for s in new_state.get_selection().iter() {
-                match s {
-                    Selection::Strand(_, s_id) => {
-                        selected_strands.insert(*s_id as usize);
-                    }
-                    Selection::Bound(_, n1, n2) => {
-                        selected_xovers.insert((*n1, *n2));
-                    }
-                    Selection::Xover(_, xover_id) => {
-                        if let Some((n1, n2)) = self.design.get_xover_with_id(*xover_id) {
-                            selected_xovers.insert((n1, n2));
-                        }
-                    }
-                    Selection::Helix(_, h) => {
-                        if let Some(flat_helix) = FlatHelix::from_real(*h as usize, id_map) {
-                            selected_helices.push(flat_helix.flat);
-                        }
-                    }
-                    _ => (),
+        for s in new_state.get_selection().iter() {
+            match s {
+                Selection::Strand(_, s_id) if !new_state.is_changing_color() => {
+                    selected_strands.insert(*s_id as usize);
                 }
+                Selection::Bound(_, n1, n2) => {
+                    selected_xovers.insert((*n1, *n2));
+                }
+                Selection::Xover(_, xover_id) => {
+                    if let Some((n1, n2)) = self.design.get_xover_with_id(*xover_id) {
+                        selected_xovers.insert((n1, n2));
+                    }
+                }
+                Selection::Helix(_, h) => {
+                    if let Some(flat_helix) = FlatHelix::from_real(*h as usize, id_map) {
+                        selected_helices.push(flat_helix.flat);
+                    }
+                }
+                Selection::Nucleotide(_, n) => {
+                    if let Some(flat_nucl) = FlatNucl::from_real(n, id_map) {
+                        selected_nucls.push(flat_nucl);
+                    }
+                }
+                _ => (),
             }
         }
         for c in new_state.get_candidates().iter() {
@@ -150,6 +155,11 @@ impl Data {
                 Selection::Helix(_, h) => {
                     if let Some(flat_helix) = FlatHelix::from_real(*h as usize, id_map) {
                         candidate_helices.push(flat_helix.flat);
+                    }
+                }
+                Selection::Nucleotide(_, n) => {
+                    if let Some(flat_nucl) = FlatNucl::from_real(n, id_map) {
+                        candidate_nucls.push(flat_nucl)
                     }
                 }
                 _ => (),
@@ -183,6 +193,8 @@ impl Data {
         self.view
             .borrow_mut()
             .set_candidate_helices(candidate_helices);
+        self.view.borrow_mut().set_selected_nucls(selected_nucls);
+        self.view.borrow_mut().set_candidate_nucls(candidate_nucls);
     }
 
     fn update_strand_building_info(&self, info: Option<super::StrandBuildingStatus>) {

--- a/src/flatscene/data.rs
+++ b/src/flatscene/data.rs
@@ -49,6 +49,7 @@ pub struct Data {
     suggestions: HashMap<FlatNucl, HashSet<FlatNucl, RandomState>, RandomState>,
     id: u32,
     requests: Arc<Mutex<dyn Requests>>,
+    last_clicked_nucl: Option<FlatNucl>,
 }
 
 impl Data {
@@ -69,6 +70,7 @@ impl Data {
             suggestions: Default::default(),
             id,
             requests,
+            last_clicked_nucl: None,
         }
     }
 
@@ -877,7 +879,17 @@ impl Data {
                             new_selection.push(selection);
                         }
                     } else {
-                        let selection = Selection::Nucleotide(self.id, nucl.to_real());
+                        let selection = if Some(nucl) == self.last_clicked_nucl {
+                            if let Some(s_id) = self.get_strand_id(nucl) {
+                                self.last_clicked_nucl = None;
+                                Selection::Strand(self.id, s_id as u32)
+                            } else {
+                                Selection::Nucleotide(self.id, nucl.to_real())
+                            }
+                        } else {
+                            self.last_clicked_nucl = Some(nucl);
+                            Selection::Nucleotide(self.id, nucl.to_real())
+                        };
                         if let Some(pos) = new_selection.iter().position(|x| *x == selection) {
                             new_selection.remove(pos);
                         } else {

--- a/src/gui/left_panel.rs
+++ b/src/gui/left_panel.rs
@@ -38,7 +38,7 @@ use ensnano_design::{
 };
 use ensnano_interactor::{
     graphics::{Background3D, RenderingMode},
-    ActionMode, SelectionConversion, SelectionMode,
+    ActionMode, SelectionConversion, SelectionMode, SuggestionParameters,
 };
 
 use super::{
@@ -181,6 +181,7 @@ pub enum Message<S> {
     SelectCamera(CameraId),
     NewCustomCamera,
     UpdateCamera(CameraId),
+    NewSuggestionParameters(SuggestionParameters),
 }
 
 impl<R: Requests, S: AppState> LeftPanel<R, S> {
@@ -713,6 +714,12 @@ impl<R: Requests, S: AppState> Program for LeftPanel<R, S> {
             }
             Message::UpdateCamera(camera_id) => {
                 self.requests.lock().unwrap().update_camera(camera_id)
+            }
+            Message::NewSuggestionParameters(param) => {
+                self.requests
+                    .lock()
+                    .unwrap()
+                    .set_suggestion_parameters(param);
             }
         };
         Command::none()

--- a/src/gui/left_panel/contextual_panel.rs
+++ b/src/gui/left_panel/contextual_panel.rs
@@ -66,7 +66,7 @@ impl ContextualPanel {
                 Text::new("Tutorials")
                     .size(ui_size.head_text())
                     .width(Length::Fill)
-                    .horizontal_alignment(iced::HorizontalAlignment::Center),
+                    .horizontal_alignment(iced::alignment::Horizontal::Center),
             );
             column = column.push(Text::new("ENSnano website"));
             column = column.push(link_row(
@@ -88,7 +88,7 @@ impl ContextualPanel {
                 Row::new()
                     .width(Length::Fill)
                     .push(iced::Space::with_width(Length::FillPortion(1)))
-                    .align_items(iced::Align::Center)
+                    .align_items(iced::Alignment::Center)
                     .push(Column::new().width(Length::FillPortion(1)).push(help_btn))
                     .push(iced::Space::with_width(Length::FillPortion(1))),
             );
@@ -100,7 +100,7 @@ impl ContextualPanel {
                 Row::new()
                     .width(Length::Fill)
                     .push(iced::Space::with_width(Length::FillPortion(1)))
-                    .align_items(iced::Align::Center)
+                    .align_items(iced::Alignment::Center)
                     .push(Column::new().width(Length::FillPortion(1)).push(help_btn))
                     .push(iced::Space::with_width(Length::FillPortion(1))),
             );
@@ -261,7 +261,7 @@ fn add_help_to_column<'a, M: 'static>(
             column = column.push(
                 Text::new(l)
                     .width(Length::Fill)
-                    .horizontal_alignment(iced::HorizontalAlignment::Center),
+                    .horizontal_alignment(iced::alignment::Horizontal::Center),
             );
         } else {
             column = column.push(
@@ -269,7 +269,7 @@ fn add_help_to_column<'a, M: 'static>(
                     .push(
                         Text::new(l)
                             .width(Length::FillPortion(5))
-                            .horizontal_alignment(iced::HorizontalAlignment::Right),
+                            .horizontal_alignment(iced::alignment::Horizontal::Right),
                     )
                     .push(iced::Space::with_width(Length::FillPortion(1)))
                     .push(Text::new(r).width(Length::FillPortion(5))),
@@ -287,7 +287,7 @@ fn turn_into_help_column<'a, M: 'static>(
         Text::new("Help")
             .size(ui_size.head_text())
             .width(Length::Fill)
-            .horizontal_alignment(iced::HorizontalAlignment::Center),
+            .horizontal_alignment(iced::alignment::Horizontal::Center),
     );
     column = add_help_to_column(column, "3D view", view_3d_help(), ui_size.clone());
     column = column.push(iced::Space::with_height(Length::Units(15)));

--- a/src/gui/left_panel/discrete_value.rs
+++ b/src/gui/left_panel/discrete_value.rs
@@ -214,7 +214,7 @@ impl DiscreteValue {
         let left = Row::new()
             .push(name_text)
             .push(iced::Space::with_width(iced::Length::Fill))
-            .align_items(iced::Align::Center)
+            .align_items(iced::Alignment::Center)
             .width(iced::Length::FillPortion(4));
 
         let middle = Row::new()
@@ -231,7 +231,7 @@ impl DiscreteValue {
             .push(left)
             .push(middle)
             .push(right)
-            .align_items(iced::Align::Center)
+            .align_items(iced::Alignment::Center)
             .into()
     }
 

--- a/src/gui/left_panel/tabs/edition_tab.rs
+++ b/src/gui/left_panel/tabs/edition_tab.rs
@@ -165,6 +165,13 @@ macro_rules! add_suggestion_parameters_checkboxes {
         ));
         let suggestion_parameters = $app_state.get_suggestion_parameters().clone();
         $ret = $ret.push(right_checkbox(
+            suggestion_parameters.include_xover_ends,
+            "Include Xover ends",
+            move |b| Message::NewSuggestionParameters(suggestion_parameters.with_xover_ends(b)),
+            $ui_size,
+        ));
+        let suggestion_parameters = $app_state.get_suggestion_parameters().clone();
+        $ret = $ret.push(right_checkbox(
             suggestion_parameters.ignore_groups,
             "All helices",
             move |b| Message::NewSuggestionParameters(suggestion_parameters.with_ignore_groups(b)),

--- a/src/gui/left_panel/tabs/edition_tab.rs
+++ b/src/gui/left_panel/tabs/edition_tab.rs
@@ -145,6 +145,27 @@ macro_rules! add_tighten_helices_button {
     };
 }
 
+macro_rules! add_suggestion_parameters_checkboxes {
+    ($ret: ident, $self: ident, $app_state: ident, $ui_size: ident) => {
+        let suggestion_parameters = $app_state.get_suggestion_parameters().clone();
+        $ret = $ret.push(right_checkbox(
+            suggestion_parameters.include_scaffold,
+            "Show suggestions involving scaffold",
+            move |b| {
+                Message::NewSuggestionParameters(suggestion_parameters.with_include_scaffod(b))
+            },
+            $ui_size,
+        ));
+        let suggestion_parameters = $app_state.get_suggestion_parameters().clone();
+        $ret = $ret.push(right_checkbox(
+            suggestion_parameters.include_intra_strand,
+            "Show intra strand suggestions",
+            move |b| Message::NewSuggestionParameters(suggestion_parameters.with_intra_strand(b)),
+            $ui_size,
+        ));
+    };
+}
+
 impl<S: AppState> EditionTab<S> {
     pub fn new() -> Self {
         Self {
@@ -180,6 +201,9 @@ impl<S: AppState> EditionTab<S> {
         if app_state.get_selection_mode() == SelectionMode::Strand {
             add_color_square!(ret, self, color_square);
         }
+
+        subsection!(ret, ui_size, "Suggestions Parameters");
+        add_suggestion_parameters_checkboxes!(ret, self, app_state, ui_size);
 
         subsection!(ret, ui_size, "Tighten 2D helices");
         add_tighten_helices_button!(ret, self, app_state, ui_size, roll_target_helices);

--- a/src/gui/left_panel/tabs/edition_tab.rs
+++ b/src/gui/left_panel/tabs/edition_tab.rs
@@ -150,7 +150,7 @@ macro_rules! add_suggestion_parameters_checkboxes {
         let suggestion_parameters = $app_state.get_suggestion_parameters().clone();
         $ret = $ret.push(right_checkbox(
             suggestion_parameters.include_scaffold,
-            "Show suggestions involving scaffold",
+            "Include scaffold",
             move |b| {
                 Message::NewSuggestionParameters(suggestion_parameters.with_include_scaffod(b))
             },
@@ -159,8 +159,15 @@ macro_rules! add_suggestion_parameters_checkboxes {
         let suggestion_parameters = $app_state.get_suggestion_parameters().clone();
         $ret = $ret.push(right_checkbox(
             suggestion_parameters.include_intra_strand,
-            "Show intra strand suggestions",
+            "Intra strand suggestions",
             move |b| Message::NewSuggestionParameters(suggestion_parameters.with_intra_strand(b)),
+            $ui_size,
+        ));
+        let suggestion_parameters = $app_state.get_suggestion_parameters().clone();
+        $ret = $ret.push(right_checkbox(
+            suggestion_parameters.ignore_groups,
+            "All helices",
+            move |b| Message::NewSuggestionParameters(suggestion_parameters.with_ignore_groups(b)),
             $ui_size,
         ));
     };

--- a/src/gui/left_panel/tabs/edition_tab.rs
+++ b/src/gui/left_panel/tabs/edition_tab.rs
@@ -200,7 +200,7 @@ impl<S: AppState> EditionTab<S> {
         let mut ret = Column::new().spacing(5);
         let selection = app_state.get_selection_as_dnaelement();
         let roll_target_helices = self.get_roll_target_helices(&selection);
-        section!(ret, ui_size, "Eddition");
+        section!(ret, ui_size, "Edition");
         add_roll_slider!(ret, self, app_state, ui_size);
         add_autoroll_button!(ret, self, app_state, roll_target_helices);
 

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -205,6 +205,7 @@ impl<R: Requests, S: AppState> GuiState<R, S> {
     }
 
     fn queue_top_bar_message(&mut self, message: top_bar::Message<S>) {
+        log::trace!("Queue top bar {:?}", message);
         if let GuiState::TopBar(ref mut state) = self {
             state.queue_message(message)
         } else {
@@ -213,6 +214,7 @@ impl<R: Requests, S: AppState> GuiState<R, S> {
     }
 
     fn queue_left_panel_message(&mut self, message: left_panel::Message<S>) {
+        log::trace!("Queue left panel {:?}", message);
         if let GuiState::LeftPanel(ref mut state) = self {
             state.queue_message(message)
         } else {
@@ -221,6 +223,7 @@ impl<R: Requests, S: AppState> GuiState<R, S> {
     }
 
     fn queue_status_bar_message(&mut self, message: status_bar::Message<S>) {
+        log::trace!("Queue status_bar {:?}", message);
         if let GuiState::StatusBar(ref mut state) = self {
             state.queue_message(message)
         } else {
@@ -470,6 +473,7 @@ impl<R: Requests, S: AppState> GuiElement<R, S> {
                 renderer,
                 &mut self.debug,
             );
+            log::debug!("GUI request redraw");
             true
         } else {
             false
@@ -840,6 +844,7 @@ impl<S: AppState> IcedMessages<S> {
     }
 
     pub fn push_application_state(&mut self, state: S, main_state: MainState) {
+        log::trace!("Old ptr {:p}, new ptr {:p}", state, self.application_state);
         let must_update = self.application_state != state;
         self.application_state = state.clone();
         if must_update {
@@ -868,7 +873,9 @@ pub trait Multiplexer {
     fn get_texture_view(&self, element_type: ElementType) -> Option<&wgpu::TextureView>;
 }
 
-pub trait AppState: Default + PartialEq + Clone + 'static + Send + std::fmt::Debug {
+pub trait AppState:
+    Default + PartialEq + Clone + 'static + Send + std::fmt::Debug + std::fmt::Pointer
+{
     fn get_selection_mode(&self) -> SelectionMode;
     fn get_action_mode(&self) -> ActionMode;
     fn get_build_helix_mode(&self) -> ActionMode;

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -48,7 +48,7 @@ use ensnano_design::{
 };
 use ensnano_interactor::{
     graphics::{Background3D, DrawArea, ElementType, RenderingMode, SplitMode},
-    Selection, SimulationState, WidgetBasis,
+    Selection, SimulationState, SuggestionParameters, WidgetBasis,
 };
 use ensnano_interactor::{operation::Operation, ScaffoldInfo};
 use ensnano_interactor::{ActionMode, HyperboloidRequest, RollRequest, SelectionMode};
@@ -181,6 +181,7 @@ pub trait Requests: 'static + Send {
     fn set_favourite_camera(&mut self, cam_id: CameraId);
     fn update_camera(&mut self, cam_id: CameraId);
     fn set_camera_name(&mut self, cam_id: CameraId, name: String);
+    fn set_suggestion_parameters(&mut self, param: SuggestionParameters);
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -886,6 +887,7 @@ pub trait AppState: Default + PartialEq + Clone + 'static + Send + std::fmt::Deb
     fn get_curent_operation_state(&self) -> Option<CurentOpState>;
     fn get_strand_building_state(&self) -> Option<StrandBuildingStatus>;
     fn get_selected_group(&self) -> Option<GroupId>;
+    fn get_suggestion_parameters(&self) -> &SuggestionParameters;
 }
 
 pub trait DesignReader: 'static {

--- a/src/gui/top_bar.rs
+++ b/src/gui/top_bar.rs
@@ -409,8 +409,8 @@ impl<R: Requests, S: AppState> Program for TopBar<R, S> {
             .push(
                 iced::Text::new("\u{e91c}")
                     .width(Length::Fill)
-                    .horizontal_alignment(iced::HorizontalAlignment::Right)
-                    .vertical_alignment(iced::VerticalAlignment::Center),
+                    .horizontal_alignment(iced::alignment::Horizontal::Right)
+                    .vertical_alignment(iced::alignment::Vertical::Center),
             )
             .push(iced::Space::with_width(Length::Units(10)));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,6 +224,7 @@ fn main() {
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::LowPower,
                 compatible_surface: Some(&surface),
+                force_fallback_adapter: false,
             })
             .await
             .expect("Could not get adapter\n
@@ -617,7 +618,7 @@ fn main() {
                 resized = false;
                 scale_factor_changed = false;
 
-                if let Ok(frame) = surface.get_current_frame() {
+                if let Ok(frame) = surface.get_current_texture() {
                     let mut encoder = device
                         .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
 
@@ -637,7 +638,6 @@ fn main() {
                     multiplexer.draw(
                         &mut encoder,
                         &frame
-                            .output
                             .texture
                             .create_view(&wgpu::TextureViewDescriptor::default()),
                     );
@@ -646,6 +646,7 @@ fn main() {
                     // Then we submit the work
                     staging_belt.finish();
                     queue.submit(Some(encoder.finish()));
+                    frame.present();
 
                     // And update the mouse cursor
                     let iced_icon = iced_winit::conversion::mouse_interaction(mouse_interaction);

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,9 @@ const TEXTURE_FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Bgra8UnormSrgb;
 use controller::{ChanelReader, ChanelReaderUpdate, SimulationRequest};
 use ensnano_design::{Camera, Nucl};
 use ensnano_interactor::application::{Application, Notification};
-use ensnano_interactor::{CenterOfSelection, DesignOperation, DesignReader, RigidBodyConstants};
+use ensnano_interactor::{
+    CenterOfSelection, DesignOperation, DesignReader, RigidBodyConstants, SuggestionParameters,
+};
 use iced_native::Event as IcedEvent;
 use iced_wgpu::{wgpu, Backend, Renderer, Settings, Viewport};
 use iced_winit::winit::event::VirtualKeyCode;
@@ -1177,6 +1179,10 @@ impl MainState {
             .as_ref()
             .filter(|p| p.is_file())
             .map(|p| p.as_ref())
+    }
+
+    fn set_suggestion_parameters(&mut self, param: SuggestionParameters) {
+        self.modify_state(|s| s.with_suggestion_parameters(param), false)
     }
 }
 

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -37,7 +37,7 @@ use ensnano_design::{
 };
 use ensnano_interactor::{
     graphics::{Background3D, RenderingMode},
-    HyperboloidRequest, RigidBodyConstants,
+    HyperboloidRequest, RigidBodyConstants, SuggestionParameters,
 };
 
 use std::collections::VecDeque;
@@ -117,4 +117,5 @@ pub struct Requests {
     pub new_paste_candiate: Option<Option<Nucl>>,
     pub new_double_strand_parameters: Option<Option<(isize, usize)>>,
     pub new_center_of_selection: Option<Option<CenterOfSelection>>,
+    pub new_suggestion_parameters: Option<SuggestionParameters>,
 }

--- a/src/requests/impl_gui.rs
+++ b/src/requests/impl_gui.rs
@@ -335,6 +335,10 @@ impl GuiRequests for Requests {
                 name,
             }))
     }
+
+    fn set_suggestion_parameters(&mut self, param: SuggestionParameters) {
+        self.new_suggestion_parameters = Some(param);
+    }
 }
 
 fn rigid_parameters(parameters: RigidBodyParametersRequest) -> RigidBodyConstants {

--- a/src/requests/poll.rs
+++ b/src/requests/poll.rs
@@ -377,4 +377,8 @@ pub(crate) fn poll_all<R: DerefMut<Target = Requests>>(
     for action in requests.keep_proceed.drain(..) {
         main_state.pending_actions.push_back(action)
     }
+
+    if let Some(param) = requests.new_suggestion_parameters.take() {
+        main_state.set_suggestion_parameters(param);
+    }
 }

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -581,7 +581,11 @@ impl<S: AppState> Scene<S> {
             .borrow_mut()
             .update_view(&new_state, &self.older_state);
         self.older_state = new_state;
-        self.view.borrow().need_redraw()
+        let ret = self.view.borrow().need_redraw();
+        if ret {
+            log::debug!("Scene requests redraw");
+        }
+        ret
     }
 
     /// Draw the scene

--- a/src/scene.rs
+++ b/src/scene.rs
@@ -861,6 +861,7 @@ pub trait AppState: Clone {
     fn get_selected_element(&self) -> Option<CenterOfSelection>;
     fn get_current_group_pivot(&self) -> Option<ensnano_design::group_attributes::GroupPivot>;
     fn get_current_group_id(&self) -> Option<ensnano_design::GroupId>;
+    fn suggestion_parameters_were_updated(&self, other: &Self) -> bool;
 }
 
 pub trait Requests {

--- a/src/scene/controller.rs
+++ b/src/scene/controller.rs
@@ -356,7 +356,11 @@ fn ctrl(modifiers: &ModifiersState) -> bool {
 }
 
 pub(super) trait Data {
-    fn element_to_nucl(&self, element: &Option<SceneElement>, _: bool) -> Option<(Nucl, usize)>;
+    fn element_to_nucl(
+        &self,
+        element: &Option<SceneElement>,
+        non_phantom: bool,
+    ) -> Option<(Nucl, usize)>;
     fn get_nucl_position(&self, nucl: Nucl, d_id: usize) -> Option<Vec3>;
     fn attempt_xover(
         &self,

--- a/src/scene/data.rs
+++ b/src/scene/data.rs
@@ -114,7 +114,9 @@ impl<R: DesignReader> Data<R> {
         if self.discs_need_update(app_state, older_app_state) {
             self.update_discs(app_state);
         }
-        if app_state.design_was_modified(older_app_state) {
+        if app_state.design_was_modified(older_app_state)
+            || app_state.suggestion_parameters_were_updated(older_app_state)
+        {
             self.update_instances();
         }
 


### PR DESCRIPTION
Fix #13 

This PR changes the behavior of the 2D interface by remapping the Mouse buttons 
The current changes are

    - Left Clicking on a nucleotide selects it, clicking again selects the strands on which the nucleotide lies
    - Right Clicking on a nucleotide cuts the strands at that position, or merge it with the neighboring strand (this was the previous behavior of Left Clicking on a nucleotide)
    - Double Left clicking on a nucleotide center the nucleotide in the 3D view (previously this was done by double right clicking)
